### PR TITLE
minor: remove dependent exception module for aix

### DIFF
--- a/libbeat/publisher/includes/includes.go
+++ b/libbeat/publisher/includes/includes.go
@@ -28,5 +28,4 @@ import (
 	_ "github.com/elastic/beats/libbeat/outputs/logstash"
 	_ "github.com/elastic/beats/libbeat/outputs/redis"
 	_ "github.com/elastic/beats/libbeat/publisher/queue/memqueue"
-	_ "github.com/elastic/beats/libbeat/publisher/queue/spool"
 )


### PR DESCRIPTION
minor: remove dependent exception module for aix
![image](https://user-images.githubusercontent.com/30516472/126895962-4b93c6a1-3f5a-44b3-be00-dde9fe373b55.png)